### PR TITLE
Initial version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,132 @@
+Beaver
+======
+
+Beaver is a collection of scripts and utilities to keep
+[Travis](https://travis-ci.org) builds in a DRY fashion.
+
+Features
+--------
+
+* **Docker:** Beaver allows you to run your build/tests in
+  [Docker](https://docker.com/) containers easily, but building a repo-provided
+  image and running stuff inside it.
+
+* **Bintray:** Beaver provides scripts to easily upload Debian packages to
+  [Bintray](https://bintray.com/) repositories (Travis support is a bit clumsy).
+
+
+Usage
+-----
+
+* Add it as a submodule:
+
+  ```sh
+  git submodule add -n beaver \
+      https://github.com/sociomantic-tsunami/beaver.git submodules/beaver
+  ```
+
+* Add a shortcut to Beaver's bin path to `.travis.yml`:
+
+  ```yml
+  env:
+      global:
+          - PATH="$(git config -f .gitmodules submodule.beaver.path)/bin:$PATH"
+  ```
+
+
+Docker
+------
+
+To use Docker in you builds, Beaver expects a `Dockerfile`, even if it's just to
+specify which Docker image to use. Then you need to build the Docker image
+(normally in the `install:` section of your `.travis.yml` file).
+
+The simplest use case would be:
+
+* `Dockerfile`
+
+  ```dockerfile
+  FROM someimage:sometag
+  ```
+
+* `.travis.yml`
+
+  ```yml
+  install: beaver docker build .
+  ```
+
+`beaver docker build` is just a thin wrapper over `docker build` to add some
+default options (`--pull -t beaver` in particular).
+
+You can pass extra `docker build` options to `beaver docker build`, for example
+to use a different `Dockerfile`:
+
+```yml
+install: beaver docker build -f docker/Dockerfile .
+```
+
+You can also use this to do matrix builds with different `Dockerfile`s, for
+example:
+
+* `docker/Dockerfile.trusty`
+
+  ```dockerfile
+  FROM ubuntu:trusty
+  ```
+
+* `docker/Dockerfile.xenial`
+
+  ```dockerfile
+  FROM ubuntu:xenial
+  ```
+
+* `.travis.yml`
+
+  ```yml
+  env:
+      matrix:
+          - DIST=trusty
+          - DIST=xenial
+
+  install: beaver docker build -t "docker/Dockerfile.$DIST" .
+  ```
+
+Then use `beaver docker run` to run commands inside the docker container (which,
+as you might think, is just a thin wrapper over `docker run` passing some
+options and the image to use, as well as all Travis environment variables,
+mapping the working directory, etc.). For example:
+
+```yml
+script:
+    - beaver docker run make all
+    - beaver docker run make test
+```
+
+If you need to pass extra variables to `docker run` you can do it by using the
+`BEAVER_DOCKER_VARS` environment variable. To make it globally, you can do, for
+example:
+
+```yml
+env:
+    global:
+        - BEAVER_DOCKER_VARS="CC DIST"
+    matrix:
+        - DIST=trusty CC=gcc
+        - DIST=xenial CC=gcc
+        - DIST=xenial CC=clang
+
+install: beaver docker build -f "docker/Dockerfile.$DIST" .
+```
+
+The docker image name is `beaver`.
+
+
+beaver install
+--------------
+
+This command is an easy entry point for projects that want to use some
+conventions.
+
+This script just builds the image for now, but if the `$DIST` environment
+variable is defined, then it looks for the `Dockerfile.$DIST` file instead of
+the regular `Dockerfile`.

--- a/bin/beaver
+++ b/bin/beaver
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Copyright sociomantic labs GmbH 2017.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+d="$(dirname "$0")"
+
+# Look if the module is already present as a built-in beaver command
+module="$1"
+shift
+test -x "$d/beaver-$module" &&
+	exec "$d/beaver-$module" "$@"
+
+# If not get the command
+cmd="$1"
+shift
+
+# Run the module's command
+exec "$d/$module/$cmd" "$@"

--- a/bin/beaver-install
+++ b/bin/beaver-install
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Copyright sociomantic labs GmbH 2017.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+d="$(dirname "$0")"
+
+# Build the docker image using .$DIST as suffix if present
+"$d/beaver" docker build -f "Dockerfile${DIST:+.$DIST}" .

--- a/bin/bintray/upload
+++ b/bin/bintray/upload
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+# Overrideable configuration
+PUBLISH=${PUBLISH:-true}
+OVERRIDE=${OVERRIDE:-false}
+DIST=${DIST:-xenial} # Normally set by Travis
+
+# BINTRAY_USER and BINTRAY_API_KEY must be always present
+
+
+die()
+{
+	echo "Error: $@" >&2
+	exit 1
+}
+
+test -z "$BINTRAY_USER" &&
+	die "No BINTRAY_USER environment variable defined!"
+
+bt()
+{
+	cmd="$1"
+	shift
+	# Dummy config to avoid jfrog to stop and ask questions...
+	jfrog bt config --user=nobody --key=nokey --licenses=nolicense
+	echo jfrog bt "$cmd" "$@"
+	jfrog bt "$cmd" --user="$BINTRAY_USER" --key="$BINTRAY_API_KEY" "$@"
+}
+
+
+# Parse arguments
+################################################################################
+
+test "$#" -lt 3 &&
+	die "Usage: $0 TAG SUBJECT/REPO/PACKAGE FILE..."
+
+tag=$1
+dst="$2/$tag"
+shift 2
+
+test "$(git cat-file -t refs/tags/$tag)" != "tag" &&
+	die "VERSION $tag should be a valid git annotated tag!"
+
+
+# Create version
+################################################################################
+bt version-create \
+		--desc="$(git for-each-ref --format "%(contents:subject)" \
+			"refs/tags/$tag")" \
+		--vcs-tag="$tag" \
+		--released="$(git for-each-ref \
+			--format "%(taggerdate:format:%FT%H:%M:%S.000Z)" \
+			"refs/tags/$tag")" \
+		"$dst" 2> /tmp/bt-version-create.errors
+# We don't consider conflicts as errors, since we have a race condition in
+# matrix builds
+if test "$?" -ne 0
+then
+	cat /tmp/bt-version-create.errors >&2
+	grep -q '^\[Error\] Bintray response: 409 Conflict' \
+			/tmp/bt-version-create.errors ||
+		die "Could not create version $dst!"
+fi
+
+
+# Upload files
+################################################################################
+
+component="release"
+if echo "$tag" | grep -q -- '.\+-.\+'; then
+	component="prerelease"
+fi
+
+for f in "$@"
+do
+	bt upload \
+			--publish="$PUBLISH" \
+			--override="$OVERRIDE" \
+			--deb="$DIST/$component/$(echo "$f" | \
+				sed 's|^.*_\([^_]\+\)\.deb$|\1|')" \
+			"$f" "$dst" ||
+		die "Could not upload file $f to $dst!"
+done

--- a/bin/docker/build
+++ b/bin/docker/build
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Copyright sociomantic labs GmbH 2017.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+set -xe
+
+# Build the docker image
+docker build --pull -t beaver "$@"

--- a/bin/docker/run
+++ b/bin/docker/run
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Copyright sociomantic labs GmbH 2017.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+set -e
+
+# Environment variables to export (Travis-defined + BEAVER_DOCKER_VARS)
+env_vars="$(printenv -0 | sed -zn 's/^\([^=]\+\)=.*$/\1\n/p')"
+travis_vars="USER HOME LANG LC_ALL DEBIAN_FRONTEND \
+	RAILS_ENV RACK_ENV MERB_ENV JRUBY_OPTS JAVA_HOME \
+	CI CONTINUOUS_INTEGRATION $(echo "$env_vars" | grep '^TRAVIS')"
+beaver_vars="DIST"
+exported_env_vars="$travis_vars $beaver_vars $BEAVER_DOCKER_VARS"
+docker_env_var_args=$(echo $exported_env_vars | sed -n 's/\([^ ]\+\)/-e \1/gp')
+
+# Run the actual command
+set -x
+docker run -ti --rm -v "$HOME:$HOME" -v "$PWD:$PWD" -w "$PWD" -u "$(id -u)" \
+	$docker_env_var_args beaver "$@"


### PR DESCRIPTION
For now beaver is basically one meta-command that has sub-commands and
extensions to perform common tasks. In this initial version there is
a docker extension that has 2 commands: build and run. This is intended
to standardize how docker images are build and run in beaver projects.

There is also a bintray extension that for now has only an upload
command to upload Debian packages, since Travis build-in support is not
the most convenient.

Then there is the install beaver sub-command that just calls docker
build in a more specific way, that should be more convenient for most
projects. This command can perform other setup steps in the future that
are not related to docker.

A draft README file is also provided, but for now it acts more as
a reminder of how things work than proper end-user documentation.