### PR TITLE
Shorten and export bintray user/pass env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,42 @@ conventions.
 This script just builds the image for now, but if the `$DIST` environment
 variable is defined, then it looks for the `Dockerfile.$DIST` file instead of
 the regular `Dockerfile`.
+
+Bintray
+-------
+
+To upload Debian packages to Bintray use the `beaver bintray upload` command. By
+default you only need to pass the path to the files to upload. The credentials
+will be obtained from `$BINTRAY_USER` and `$BINTRAY_KEY` environment variables
+and the destination to `org/repo/repo` where `org` is the GitHub
+organization/user and `repo` is the GitHub repo name (this is obtained from
+`$TRAVIS_SLUG`). By default the current tag being buit is used as the version
+(from `$TRAVIS_TAG`).
+
+Files are put in the debian repository `$DIST/(pre)release/ARCH` where `$DIST`
+can also be overriden via command-line arguments and if not present at all
+defaults to `$(lsb_release -cs)`, releases are put in the `release` components
+and pre-releases (tags with a `-` as per [SemVer]() specification) in the
+`prerelease` component. Finally `ARCH` is the architecture and is calculated
+from the Debian package file name (normally packages end with `_ARCH.deb`), but
+can also be overriden via command-line arguments.
+
+For more options and a more in-depth description of defaults run `beaver bintray
+upload -h` for online help.
+
+The most common way to upload files is to add this to your `.travis.yml`:
+
+```yml
+deploy:
+    provider: script
+    script: beaver bintray upload *.deb # Put the right locatio here
+    skip_cleanup: true
+    on:
+        tags: true
+```
+
+And then define `$BINTRAY_USER` and `$BINTRAY_KEY` as secret/encrypted
+repository environment variables.
+
+Travis already have a provider for deploying to bintray, but it is extremely
+inconvenient as it requires to produce one json file per file to upload.

--- a/bin/bintray/upload
+++ b/bin/bintray/upload
@@ -10,8 +10,8 @@
 # Defaults
 dest="$TRAVIS_SLUG/$(basename "$TRAVIS_SLUG")"
 dist=${DIST:-$(lsb_release -cs)}
-user="$BEAVER_BINTRAY_USER"
-pass="$BEAVER_BINTRAY_KEY"
+user="$BINTRAY_USER"
+pass="$BINTRAY_KEY"
 publish=true
 override=false
 comp_release=release
@@ -42,10 +42,10 @@ Options:
 	"$dist" currently)
 -u USER
 	bintray user to use to upload files (by default taken from
-	\$BEAVER_BINTRAY_USER)
+	\$BINTRAY_USER)
 -k KEY
 	bintray API key to use to upload files (by default taken from
-	\$BEAVER_BINTRAY_KEY)
+	\$BINTRAY_KEY)
 -P
 	don't publish uploaded packages (packages are published by default)
 -o
@@ -130,11 +130,9 @@ test -z "$dist" &&
 	usage_die "You must specify -D DEST if \$DIST is not present and " \
 		"there is no working lsb_release command!"
 test -z "$user" &&
-	usage_die "You must specify -u USER if \$BEAVER_BINTRAY_USER is not " \
-		"present!"
+	usage_die "You must specify -u USER if \$BINTRAY_USER is not present!"
 test -z "$key" &&
-	usage_die "You must specify -k KEY if \$BEAVER_BINTRAY_KEY is not " \
-		"present!"
+	usage_die "You must specify -k KEY if \$BINTRAY_KEY is not present!"
 test -z "$comp_release" &&
 	usage_die "-r NAME should not be empty!"
 test -z "$comp_prerelease" &&

--- a/bin/docker/run
+++ b/bin/docker/run
@@ -10,7 +10,7 @@ env_vars="$(printenv -0 | sed -zn 's/^\([^=]\+\)=.*$/\1\n/p')"
 travis_vars="USER HOME LANG LC_ALL DEBIAN_FRONTEND \
 	RAILS_ENV RACK_ENV MERB_ENV JRUBY_OPTS JAVA_HOME \
 	CI CONTINUOUS_INTEGRATION $(echo "$env_vars" | grep '^TRAVIS')"
-beaver_vars="DIST"
+beaver_vars="DIST BINTRAY_USER BINTRAY_KEY"
 exported_env_vars="$travis_vars $beaver_vars $BEAVER_DOCKER_VARS"
 docker_env_var_args=$(echo $exported_env_vars | sed -n 's/\([^ ]\+\)/-e \1/gp')
 


### PR DESCRIPTION
Since the command now has options to specify the user and API key for
bintray, we can use a shorter and more convenient env variables to set
them (if you want to override them, use the command-line arguments).

Also make sure beaver run exports those variables.