### PR TITLE
Fix the bintray upload command

### DIFF
--- a/Dockerfile.trusty
+++ b/Dockerfile.trusty
@@ -4,4 +4,4 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 #
 # This Dockerfile is just for testing
-FROM sociomantictsunami/base:v2test-trusty
+FROM sociomantictsunami/base:trusty-v2-test

--- a/Dockerfile.xenial
+++ b/Dockerfile.xenial
@@ -4,4 +4,4 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 #
 # This Dockerfile is just for testing
-FROM sociomantictsunami/base:v2test-xenial
+FROM sociomantictsunami/base:xenial-v2-test

--- a/bin/bintray/upload
+++ b/bin/bintray/upload
@@ -141,6 +141,10 @@ test -z "$comp_prerelease" &&
 # Append the tag to the destination for bintray
 dest="$dest/$tag"
 
+# Check the presence of the jfrog tool
+jfrog --help > /dev/null ||
+	exit $?
+
 
 # Create version
 ################################################################################

--- a/bin/bintray/upload
+++ b/bin/bintray/upload
@@ -17,7 +17,26 @@ publish=true
 override=false
 comp_release=release
 comp_prerelease=prerelease
+in_docker=true
 arch=
+
+
+# If we run inside docker, just forward the command
+# Normally we run inside docker because it's assumed the used docker image will
+# have the jfrog tool
+for a in "$@"
+do
+	if test "$a" = "-N"
+	then
+		in_docker=false
+		break
+	fi
+done
+if $in_docker
+then
+	beaver run "$0" -N "$@"
+	exit $?
+fi
 
 
 # Command usage string / help
@@ -58,6 +77,8 @@ Options:
 -a ARCH
 	name of the Debian architecture to upload to (default: auto-detect from
 	file name)
+-N
+	don't run inside docker (by default this command runs inside docker)
 -h
 	show this help message and exit
 EOT
@@ -98,7 +119,7 @@ bt()
 # Parse arguments
 ################################################################################
 
-while getopts t:d:D:u:k:Por:p:a:h arg
+while getopts t:d:D:u:k:Por:p:a:Nh arg
 do
 	case "$arg" in
 		t) tag="$OPTARG" ;;
@@ -111,6 +132,7 @@ do
 		r) comp_release="$OPTARG" ;;
 		p) comp_prerelease="$OPTARG" ;;
 		p) arch="$OPTARG" ;;
+		N) in_docker=false ;; # This was already parsed, but still
 		h) usage ; exit 0 ;;
 		\?) usage_die ;;
 	esac

--- a/bin/bintray/upload
+++ b/bin/bintray/upload
@@ -8,6 +8,7 @@
 
 
 # Defaults
+tag="$TRAVIS_TAG"
 dest="$TRAVIS_SLUG/$(basename "$TRAVIS_SLUG")"
 dist=${DIST:-$(lsb_release -cs)}
 user="$BINTRAY_USER"


### PR DESCRIPTION
This command has a couple of problems, most notably the TRAVIS_TAG
wasn't really used by default and it didn't run inside docker, so
probably the jfrog command wasn't to be found.