### PR TITLE
docker: Fix locale to C.UTF-8

### DIFF
--- a/Dockerfile.trusty
+++ b/Dockerfile.trusty
@@ -4,4 +4,4 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 #
 # This Dockerfile is just for testing
-FROM sociomantictsunami/base:trusty-v2-test
+FROM sociomantictsunami/base:trusty-v2

--- a/Dockerfile.xenial
+++ b/Dockerfile.xenial
@@ -4,4 +4,4 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 #
 # This Dockerfile is just for testing
-FROM sociomantictsunami/base:xenial-v2-test
+FROM sociomantictsunami/base:xenial-v2

--- a/bin/docker/run
+++ b/bin/docker/run
@@ -7,7 +7,7 @@ set -e
 
 # Environment variables to export (Travis-defined + BEAVER_DOCKER_VARS)
 env_vars="$(printenv -0 | sed -zn 's/^\([^=]\+\)=.*$/\1\n/p')"
-travis_vars="USER HOME LANG LC_ALL DEBIAN_FRONTEND \
+travis_vars="USER HOME DEBIAN_FRONTEND \
 	RAILS_ENV RACK_ENV MERB_ENV JRUBY_OPTS JAVA_HOME \
 	CI CONTINUOUS_INTEGRATION $(echo "$env_vars" | grep '^TRAVIS')"
 beaver_vars="DIST BINTRAY_USER BINTRAY_KEY"
@@ -20,4 +20,4 @@ uid="$(id -u)"
 # Run the actual command
 set -x
 docker run -ti --rm -v "$HOME:$HOME" -v "$PWD:$PWD" -w "$PWD" -u "$uid" \
-	$docker_env_var_args beaver "$@"
+	-e LANG=C.UTF-8 -e LC_ALL=C.UTF-8 $docker_env_var_args beaver "$@"

--- a/test/hello
+++ b/test/hello
@@ -11,3 +11,8 @@ if test -n "$DIST"
 then
 	test "$DIST" = "$(lsb_release -cs)"
 fi
+
+# Some encoding tests
+test "$LC_ALL" = "C.UTF-8"
+test "$LANG" = "C.UTF-8"
+python3 -c 'import sys; assert sys.stdout.encoding == "UTF-8"'


### PR DESCRIPTION
The docker images usually don't have locales configured, because it's
hard to know which locale should be really used. Because of this, it's
safer to just specify the character set, and use the "C" locale, which
is present everywhere.