### PR TITLE
docker run: Allow passing extra options

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ env:
 install: beaver docker build -f "docker/Dockerfile.$DIST" .
 ```
 
+You can also pass extra options to `docker` by exporting the
+`BEAVER_DOCKER_OPTS`.
+
 The docker image name is `beaver`.
 
 

--- a/bin/docker/run
+++ b/bin/docker/run
@@ -20,4 +20,5 @@ uid="$(id -u)"
 # Run the actual command
 set -x
 docker run -ti --rm -v "$HOME:$HOME" -v "$PWD:$PWD" -w "$PWD" -u "$uid" \
-	-e LANG=C.UTF-8 -e LC_ALL=C.UTF-8 $docker_env_var_args beaver "$@"
+	-e LANG=C.UTF-8 -e LC_ALL=C.UTF-8 $docker_env_var_args \
+	$BEAVER_DOCKER_OPTS beaver "$@"


### PR DESCRIPTION
Extra options can be passed via the environment variable
`BEAVER_DOCKER_OPTS`.