### PR TITLE
Add first version of D building scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,13 @@ env:
         - PATH="$TRAVIS_BUILD_DIR/bin:$PATH"
 
     matrix:
-        - DIST=
-        - DIST=trusty
-        - DIST=xenial
+        - DIST=       DMD=dmd-transitional
+        - DIST=trusty DMD=dmd1
+        - DIST=xenial DMD=2.070.2.s12
 
 install:
-    - beaver install
+    - beaver dlang install
 
 script:
     - beaver docker run test/hello
+    - beaver dlang make

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,7 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 #
 # This Dockerfile is just for testing
-FROM sociomantictsunami/base
+FROM sociomantictsunami/dlang
+ARG DMD_PKG
+ENV DMD_PKG="$DMD_PKG"
+RUN apt-get update && apt-get -y install $DMD_PKG

--- a/Dockerfile.trusty
+++ b/Dockerfile.trusty
@@ -4,4 +4,7 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 #
 # This Dockerfile is just for testing
-FROM sociomantictsunami/base:trusty-v2
+FROM sociomantictsunami/dlang:trusty-v2
+ARG DMD_PKG
+ENV DMD_PKG="$DMD_PKG"
+RUN apt-get update && apt-get -y install $DMD_PKG

--- a/Dockerfile.xenial
+++ b/Dockerfile.xenial
@@ -4,4 +4,7 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 #
 # This Dockerfile is just for testing
-FROM sociomantictsunami/base:xenial-v2
+FROM sociomantictsunami/dlang:xenial-v2
+ARG DMD_PKG
+ENV DMD_PKG="$DMD_PKG"
+RUN apt-get update && apt-get -y install $DMD_PKG

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+ifndef DC
+    $(error DC variable is not defined)
+endif
+
+ifndef DVER
+    $(error DVER variable is not defined)
+endif
+
+.PHONY: all
+all: test
+
+.PHONY: test
+# We need to specify -of because dmd1 will fail trying to create the temporary
+# file as 'test' which is already a directory name
+test:
+	$(DC) -oftest.d.bin -run test/test.d
+
+.PHONY: d2conv
+d2conv:
+	test "$(DVER)" = 2

--- a/bin/dlang/install
+++ b/bin/dlang/install
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Copyright sociomantic labs GmbH 2017.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+#
+# Build a docker image for D projects
+set -eu
+
+# Package name deduced based on supplied DMD version
+case "$DMD" in
+    dmd*   ) PKG= ;;
+    1.*    ) PKG="dmd1=$DMD-$DIST" ;;
+    2.*.s* ) PKG="dmd-transitional=$DMD-$DIST" ;;
+    2.*    ) PKG="dmd-bin=$DMD" ;;
+    *      ) echo "Unknown \$DMD ($DMD)" >&2; false ;;
+esac
+
+# Build the docker image using .$DIST as suffix if present
+"$(dirname "$0")/../beaver" install --build-arg "DMD_PKG=$PKG" "$@"

--- a/bin/dlang/make
+++ b/bin/dlang/make
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Copyright sociomantic labs GmbH 2017.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+#
+# Build D applications
+set -eu
+
+# Set default arguments if none are passed
+if test $# -eq 0
+then
+    set -- all test
+fi
+
+# Paths
+r=$(dirname $0)/../..
+beaver=$r/bin/beaver
+
+# Use general dlang utilities
+. $r/lib/dlang.sh
+
+# Set the DC and DVER environment variables and export them to docker
+set_dc_dver
+export BEAVER_DOCKER_VARS="${BEAVER_DOCKER_VARS:-} DC DVER"
+
+# First convert code if we are building D2
+if_d 2 beaver make d2conv
+
+# Then just build
+$beaver make "$@"

--- a/lib/dlang.sh
+++ b/lib/dlang.sh
@@ -1,0 +1,62 @@
+# Copyright sociomantic labs GmbH 2017.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+#
+# Utility functions for D build scripts
+#
+# Use:
+#
+# . lib/dlang.sh
+
+# Sets the DC and DVER environment variables based on the DMD environment
+# variable, if present. The DMD variable is expected to hold the DMD version to
+# use:
+# For DMD 1.x, DC will be set to dmd1 and DVER to 1.
+# For DMD 2.x.y.sN, DC will be set to dmd-transitional and DVER to 2.
+# For DMD 2.x.y, DC will be set to dmd and DVER to 2.
+# It errors if DMD is not set.
+set_dc_dver() {
+    old_opts=$-
+    set -eu
+
+    # Binary name deduced based on supplied DMD version
+    case "$DMD" in
+        dmd*   ) DC="$DMD"
+                DVER=2
+                if test "$DMD" = dmd1
+                then
+                    DVER=1
+                fi
+                ;;
+        1.*    ) DC=dmd1 DVER=1 ;;
+        2.*.s* ) DC=dmd-transitional DVER=2 ;;
+        2.*    ) DC=dmd DVER=2 ;;
+        *      ) echo "Unknown \$DMD ($DMD)" >&2; false ;;
+    esac
+
+    export DC DVER
+    set $old_opts
+}
+
+# Simple function to run commands based on the D version, assuming the `DVER`
+# environment variable is set properly.
+#
+# Example:
+#
+# if_d 1 dmd1 --version # will run `dmd1 --version` only if DVER == 1
+# if_d 2 make -r d2conv # will only run the D2 conversion if DVER == 2
+if_d() {
+    old_opts=$-
+    set -eu
+
+    wanted=$1
+    shift
+    if test "$DVER" -eq "$wanted"
+    then
+        "$@"
+    fi
+
+    set $old_opts
+}
+

--- a/test/test.d
+++ b/test/test.d
@@ -1,0 +1,9 @@
+version (D_Version2)
+    mixin("extern(C) int printf(const char*, ...);");
+else
+    mixin("extern(C) int printf(char*, ...);");
+
+void main()
+{
+    printf("Yes, we can run a D program!\n".ptr);
+}


### PR DESCRIPTION
Introduce a new `dlang` subcommand to help building D1/2 projects more
easily. Please refer to the README for more details.

As a second step I will try to address the repetition in terms of image
building. My idea is to probably add a command to build the Dockerfile
based on a global Docker include file (that can have user commands) and
then add the rest automatically, including the copying of the `docker`
directory and running the build script.