### PR TITLE
Pass Bintray credential only to bintray commands

### DIFF
--- a/bin/bintray/upload
+++ b/bin/bintray/upload
@@ -34,7 +34,8 @@ do
 done
 if $in_docker
 then
-	beaver run "$0" -N "$@"
+    export BEAVER_DOCKER_VARS="$BEAVER_DOCKER_VARS BINTRAY_USER BINTRAY_KEY"
+    beaver run "$0" -N "$@"
 	exit $?
 fi
 

--- a/bin/docker/run
+++ b/bin/docker/run
@@ -10,7 +10,7 @@ env_vars="$(printenv -0 | sed -zn 's/^\([^=]\+\)=.*$/\1\n/p')"
 travis_vars="USER HOME DEBIAN_FRONTEND \
 	RAILS_ENV RACK_ENV MERB_ENV JRUBY_OPTS JAVA_HOME \
 	CI CONTINUOUS_INTEGRATION $(echo "$env_vars" | grep '^TRAVIS')"
-beaver_vars="DIST BINTRAY_USER BINTRAY_KEY"
+beaver_vars="DIST"
 exported_env_vars="$travis_vars $beaver_vars $BEAVER_DOCKER_VARS"
 docker_env_var_args=$(echo $exported_env_vars | sed -n 's/\([^ ]\+\)/-e \1/gp')
 


### PR DESCRIPTION
There is no need to pass credentials to other commands. The user can
pass credentials manually using `BEAVER_DOCKER_VARS` when needed for
other commands.