### PR TITLE
docker: Allow using a custom image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,15 @@ The simplest use case would be:
   ```
 
 `beaver docker build` is just a thin wrapper over `docker build` to add some
-default options (`--pull -t beaver` in particular).
+default options (`--pull -t $img` in particular).
+
+The image name will be taken from the `BEAVER_DOCKER_IMG` environment variable,
+if present. If not present it falls back to the result of `git config
+hub.upstream` (in case you are using the
+[git-hub](https://github.com/sociomantic-tsunami/git-hub) tool in the
+command-line. If that's empty too, then it will try with the `TRAVIS_REPO_SLUG`
+environment variable (in case it's running inside travis) and as a last resort
+it will simply use `beaver` as the image name.
 
 You can pass extra `docker build` options to `beaver docker build`, for example
 to use a different `Dockerfile`:

--- a/bin/docker/build
+++ b/bin/docker/build
@@ -3,7 +3,11 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
-set -xe
+
+# Look for a suitable image name
+img="${BEAVER_DOCKER_Iimg-$(git config hub.upstream)}"
+img="${img:-${TRAVIS_REPO_SLUG:-beaver}}"
 
 # Build the docker image
-docker build --pull -t beaver "$@"
+set -xe
+docker build --pull -t "$img" "$@"

--- a/bin/docker/run
+++ b/bin/docker/run
@@ -17,8 +17,12 @@ docker_env_var_args=$(echo $exported_env_vars | sed -n 's/\([^ ]\+\)/-e \1/gp')
 # Current user ID
 uid="$(id -u)"
 
+# Look for a suitable image name
+img="${BEAVER_DOCKER_IMG:-$(git config hub.upstream || true)}"
+img="${img:-${TRAVIS_REPO_SLUG:-beaver}}"
+
 # Run the actual command
 set -x
 docker run --rm -v "$HOME:$HOME" -v "$PWD:$PWD" -w "$PWD" -u "$uid" \
 	-e LANG=C.UTF-8 -e LC_ALL=C.UTF-8 $docker_env_var_args \
-	$BEAVER_DOCKER_OPTS beaver "$@"
+	$BEAVER_DOCKER_OPTS "$img" "$@"

--- a/relnotes/image-name.feature.md
+++ b/relnotes/image-name.feature.md
@@ -1,0 +1,16 @@
+* `docker build/run`
+
+  The image name used to build images (and then used to run commands in
+  containers based on those images now can be specified via the
+  `BEAVER_DOCKER_IMG` environment variable.
+
+  If not present it falls back to the result of `git config hub.upstream` (in
+  case you are using the
+  [git-hub](https://github.com/sociomantic-tsunami/git-hub) tool in the
+  command-line.
+
+  If that's empty too, then it will try with the `TRAVIS_REPO_SLUG` environment
+  variable (in case it's running inside travis).
+
+  If none of them are present, as a last resort, it will simply use `beaver` as
+  the image name (which was the previously used, and hard-coded, name).

--- a/tools/make-wrapper-dlang
+++ b/tools/make-wrapper-dlang
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Copyright sociomantic labs GmbH 2017.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+# This script can be used as a wrapper for make. It will check if beaver is
+# present as a submodule and if it is it will call make insider docker using
+# the dlang commands to build.
+#
+# Also the .travis.yml file is read to look for env variables, including
+# matrixes. By default the last element of the matrix is built, but you can
+# chose a different index by passing the environment variable MATRIX (negative
+# indexes can be used to count backwards). If MATRIX has the special value `*`
+# all matrix cells are built.
+#
+# This script requires Python3 and jq.
+
+BEAVER_PATH=${BEAVER_PATH:-$(git config -f .gitmodules submodule.beaver.path)}
+
+set -eu
+
+beaver="${BEAVER_PATH}/bin/beaver"
+
+# No beaver? Just regular make
+if test ! -x "$beaver"
+then
+	exec /usr/bin/make "$@"
+fi
+
+alias yaml2json='python3 -c "import sys, yaml, json; print(json.dumps(yaml.load(sys.stdin)))"'
+
+# Build one matrix cell
+build()
+{
+	eval export $(eval echo eval $(yaml2json < .travis.yml | jq ".env.global | .[]"))
+	eval export $(eval echo eval $matrix)
+	eval echo "+ MATRIX: "$matrix >&2
+	export DIST=${DIST:-$(lsb_release -cs)} DMD="${DMD:-dmd1}" TRAVIS=1
+	"$beaver" dlang install
+	rm beaver.Dockerfile.generated
+	"$beaver" dlang make "$@"
+}
+
+MATRIX=${MATRIX:--1}
+if test "$MATRIX" = "*"
+then
+	yaml2json < .travis.yml | jq ".env.matrix | .[]" | while read matrix
+	do
+		build "$@"
+	done
+else
+	matrix="$(yaml2json < .travis.yml | jq ".env.matrix | sort | .[$MATRIX]")"
+	build "$@"
+fi
+


### PR DESCRIPTION
Also, by default it will use `git config hub.upstream` or `TRAVIS_REPO_SLUG` to get a more meaningful default image name.