### PR TITLE
Change default matrix row for make-wrapper-dlang

### DIFF
--- a/tools/make-wrapper-dlang
+++ b/tools/make-wrapper-dlang
@@ -42,7 +42,7 @@ build()
 	"$beaver" dlang make "$@"
 }
 
-MATRIX=${MATRIX:--1}
+MATRIX=${MATRIX:-0}
 if test "$MATRIX" = "*"
 then
 	yaml2json < .travis.yml | jq ".env.matrix | .[]" | while read matrix


### PR DESCRIPTION
By default the last row in the matrix was chosen, but it is more common
to use the first row as the most important/common configuration to
build so it makes sense to use the first as default instead.