### PR TITLE
Mention wildcard support in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,17 @@ variable (by injecting the `DMD_PKG` docker argument and environment variable to
 the docker image generation, as well as calling `apt-get update && apt-get
 install` with the requested DMD version for you.
 
+Wildcards are supplied to `apt` as-is, which makes it possible to install latest
+package which version string matches:
+
+```yml
+env:
+    matrix:
+        - DMD=1.079.*
+        - DMD=2.070.2.s*
+```
+
+
 This means you only have to take care of installing your project dependencies
 and you don't need to do an `apt-get update` before the install.
 


### PR DESCRIPTION
Plain `apt install dmd=2.070.2` doesn't work because D-APT also includes
packaging version, i.e. 2.070.2-0

Fortunately apt recognizes star wildcard to install latest available
packaged version.