### PR TITLE
editorconfig: Fix indent for Makefiles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,4 +20,3 @@ indent_size = 2
 # Makefiles need to use tab for indentation
 [{Makefile,**.mak}]
 indent_style = tab
-tab_width = none


### PR DESCRIPTION
Just change the indent_style to use tabs, the tab_width can remain as
the indent_size (so getting an indent of 4 spaces visually, but using
only one TAB in the file).