### PR TITLE
gen-dockerfile: Fix docker repository and tag parsing

### DIFF
--- a/bin/docker/gen-dockerfile
+++ b/bin/docker/gen-dockerfile
@@ -95,14 +95,17 @@ transform_from()
 {
     # Regular expression to use to extract info from the FROM line using sed
     # \1 is the FROM and initial spaces
-    # \2 is the image name
-    # \5 is the tag name (if any)
-    # \6 is the trailing spaces or comments (if any)
-    from_sed_re='^(\s*FROM\s+)(\w+(\/\w+)?)(:(\w+))?(\s*(#.*)?)$'
+    # \2 is the "user/repository" part
+    # \3 is the "/repository" with the leading "/" (if any)
+    # \4 is the ":tag" with the leading ":" (if any)
+    # \5 is the "tag" (if any)
+    # \6 is the trailing spaces and comment (if any)
+    # \7 is the comment (if any)
+    from_sed_re='^(\s*FROM\s+)([^/:#[:space:]]+(/[^:#[:space:]]+)?)(:([^#[:space:]]+))?(\s*(#.*)?)$'
 
     # Inject the DIST part to the tag, only if there was a tag
-    tag="$(echo "$1" | sed -rn "s/$from_sed_re/\\5/ip")"
-    echo "$1" | sed -r "s/$from_sed_re/\\1\\2${tag:+:$docker_dist-}\\5\\6/i"
+    tag="$(echo "$1" | sed -rn "s|$from_sed_re|\\5|ip")"
+    echo "$1" | sed -r "s|$from_sed_re|\\1\\2${tag:+:$docker_dist-}\\5\\6|i"
 }
 
 # Do our thing

--- a/test/docker/gen-dockerfile/from.expected
+++ b/test/docker/gen-dockerfile/from.expected
@@ -1,0 +1,12 @@
+FROM user/repo:xenial-tag
+FROM user/repo:xenial-tag # comment FROM baduser/badrepo:badtag
+FROM user/repo:xenial-tag# comment FROM baduser/badrepo:badtag
+FrOm user/repo:xenial-tag
+FROM user/repo
+FROM repo
+FROM repo:xenial-tag
+     	FROM   user/repo:xenial-tag    	#   comment
+FROM user/repo:xenial-v3.0.1-rc_1
+FROM user/repo#:tag
+FROM user#/repo:tag
+FROM user # /repo:tag

--- a/test/docker/gen-dockerfile/from.input
+++ b/test/docker/gen-dockerfile/from.input
@@ -1,0 +1,12 @@
+FROM user/repo:tag
+FROM user/repo:tag # comment FROM baduser/badrepo:badtag
+FROM user/repo:tag# comment FROM baduser/badrepo:badtag
+FrOm user/repo:tag
+FROM user/repo
+FROM repo
+FROM repo:tag
+     	FROM   user/repo:tag    	#   comment
+FROM user/repo:v3.0.1-rc_1
+FROM user/repo#:tag
+FROM user#/repo:tag
+FROM user # /repo:tag

--- a/test/docker/gen-dockerfile/test
+++ b/test/docker/gen-dockerfile/test
@@ -8,7 +8,22 @@ set -xeu
 # Test help
 beaver docker gen-dockerfile -h | grep 'Usage:'
 
+# Test FROM lines
+export DIST=xenial
+echo -n > from.output
+oldIFS="$IFS"
+IFS=
+while read i
+do
+    echo "$i" | beaver docker gen-dockerfile -i - | head -n1 >> from.output
+done < from.input
+IFS="$oldIFS"
+cat from.output
+diff -u from.expected from.output
+rm from.output
+
 # Test basic usage
+export DIST=
 beaver docker gen-dockerfile > Dockerfile
 cat Dockerfile
 grep -q "FROM.*:$(lsb_release -cs)-v2" Dockerfile # Check for the host's DIST


### PR DESCRIPTION
It is quite hard to find a good reference on which characters are valid for each part of the docker repository and tag.

The user name seems to be restricted to [0-9a-z_] from experience creating users at Docker Hub.

"The Repository Name will need to be unique in that namespace, can be two to 255 characters, and can only contain lowercase letters, numbers or - and _." according to https://docs.docker.com/docker-hub/repos/#creating-a-new-repository-on-docker-hub.

"A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters." according to https://docs.docker.com/engine/reference/commandline/tag/.