### PR TITLE
Remove Trusty support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     matrix:
         - SINGLE=true
         - DIST=       DMD=dmd-transitional
-        - DIST=trusty DMD=dmd1
+        - DIST=xenial DMD=dmd1
         - DIST=xenial DMD=2.070.2.s12
 
 install: |

--- a/README.md
+++ b/README.md
@@ -170,13 +170,13 @@ Here is a sample script:
 ```sh
 set -xeu
 
-apt-get update
+apt update
 
 if test "$(lsb_release -cs)" = trusty
 then
-    apt-get install -y python2
+    apt install -y python2
 else
-    apt-get install -y python3
+    apt install -y python3
 fi
 ```
 
@@ -322,11 +322,11 @@ are many steps needed to setup the image automatically.
 
 It will install the DMD version as requested via the `DMD` environment
 variable (by injecting the `DMD_PKG` docker argument and environment variable to
-the docker image generation, as well as calling `apt-get update && apt-get
-install` with the requested DMD version for you.
+the docker image generation, as well as calling `apt update && apt install` with
+the requested DMD version for you.
 
 This means you only have to take care of installing your project dependencies
-and you don't need to do an `apt-get update` before the install.
+and you don't need to do an `apt update` before the install.
 
 Here is an example `beaver.Dockerfile` and `docker/build` script when using
 `beaver dlang install`:
@@ -337,7 +337,7 @@ FROM sociomantictsunami/dlang:v2
 
 ```sh
 #!/bin/sh
-apt-get install -f libwhatever-dev tool
+apt install -f libwhatever-dev tool
 ```
 
 Again, if you don't need extra dependencies, you can completely omit the

--- a/bin/dlang/install
+++ b/bin/dlang/install
@@ -20,13 +20,10 @@ esac
 
 # Generate the Dockerfile including the DMD_PKG argument and install the
 # relevant DMD
-# XXX: --allow-downgrades should be a safer option than --force-yes, but as
-# long as we support trusty, we need to use the latter since the former is not
-# supported in trusty
 "$beaver" docker gen-dockerfile \
         -i beaver.Dockerfile \
         -I 'ARG DMD_PKG' -I 'ENV DMD_PKG=$DMD_PKG' \
-        -I 'RUN apt-get update && apt-get -y install --force-yes $DMD_PKG' \
+        -I 'RUN apt update && apt -y install --allow-downgrades $DMD_PKG' \
         -o beaver.Dockerfile.generated
 
 # Build the docker image from the generated Dockerfile passing DMD_PKG

--- a/test/dlang/install/test
+++ b/test/dlang/install/test
@@ -6,7 +6,7 @@
 set -xeu
 
 # Test basic usage
-for DIST in trusty xenial
+for DIST in xenial
 do
     export DIST DMD=2.067.1-0
     beaver dlang install

--- a/test/docker/gen-dockerfile/test
+++ b/test/docker/gen-dockerfile/test
@@ -29,7 +29,6 @@ test_basic_dist()
     beaver docker run test -f /BUILT-1.1-Dockerfile -a -f /BUILT-1.2-build
     test "$(beaver docker run lsb_release -cs)" = "$DIST"
 }
-test_basic_dist trusty
 test_basic_dist xenial
 
 # Test complex usage with all options


### PR DESCRIPTION
Remove trusty support from all projects. Trusty is already more than 3 years old and the latest LTS (Xenial) has already been out there for more than a year, so it should be enough to maintain the latest LTS only now.