### PR TITLE
make-wrapper-dlang: Fix matrix row selection

### DIFF
--- a/tools/make-wrapper-dlang
+++ b/tools/make-wrapper-dlang
@@ -50,7 +50,7 @@ then
 		build "$@"
 	done
 else
-	matrix="$(yaml2json < .travis.yml | jq ".env.matrix | sort | .[$MATRIX]")"
+	matrix="$(yaml2json < .travis.yml | jq ".env.matrix | .[$MATRIX]")"
 	build "$@"
 fi
 


### PR DESCRIPTION
Sorting completely breaks the matrix row selection via MATRIX (and the
default). Entries should be considered in the exact same order as they
appear in the .travis.yml file.