### PR TITLE
dlang: Add a command to release converted D2 tags

### DIFF
--- a/bin/dlang/d2-release
+++ b/bin/dlang/d2-release
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Copyright sociomantic labs GmbH 2017.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+set -eu
+
+# Paths
+r=$(dirname $0)/../..
+beaver=$r/bin/beaver
+
+# Use github utilities
+. $r/lib/github.sh
+
+# Convert the code to D2
+$beaver make DVER=2 d2conv
+
+set -x
+
+# Commit the changes and tag
+git config user.name "$(git for-each-ref --format="%(taggername)" \
+        refs/tags/$TRAVIS_TAG)"
+git config user.email "$(git for-each-ref --format="%(taggeremail)" \
+        refs/tags/$TRAVIS_TAG)"
+git commit --no-verify -a -m 'Auto-convert to D2'
+
+# Create the new tag
+d2tag="$TRAVIS_TAG+d2"
+cat <<EOM | git tag -F- "$d2tag"
+$TRAVIS_TAG auto-converted to D2
+
+See https://github.com/$TRAVIS_REPO_SLUG/releases/tag/$TRAVIS_TAG for
+a complete changelog.
+EOM
+
+# Push (making sure the credentials are not leaked and using a helper
+# to get the password)
+git push "https://${GITHUB_OAUTH_TOKEN}@github.com/$TRAVIS_REPO_SLUG.git" "$d2tag"
+
+# Create GitHub release
+cat <<EOT | github_api POST "/repos/${TRAVIS_REPO_SLUG}/releases"
+{
+  "tag_name": "${d2tag}",
+  "name": "$TRAVIS_TAG auto-converted to D2",
+  "body": "See https://github.com/$TRAVIS_REPO_SLUG/releases/tag/$TRAVIS_TAG.",
+  "draft": false,
+  "prerelease": $(if echo "$TRAVIS_TAG" | grep -q -- '-'; then
+                    echo true; else echo false; fi)
+}
+EOT

--- a/lib/github.sh
+++ b/lib/github.sh
@@ -1,0 +1,57 @@
+# Copyright sociomantic labs GmbH 2017.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+#
+# This is a sh library with utilities for interacting with GitHub.
+#
+# Use:
+#
+# . lib/github.sh
+
+# Performs a GitHub API call
+#
+# The first argument is the method to use, the second is the URI (like
+# /repos"). The third argument is optional and it should contain a GitHub OAuth
+# token if auth is needed by the request. Alternatively the token will be taken
+# from the environment variable "$GITHUB_OAUTH_TOKEN" if not present as an
+# argument.
+#
+# If there is input in stdin, then it will be sent as HTTP payload in the
+# request.
+github_api()
+{
+    ( { set +x -ue; } 2>/dev/null # disable verboseness (silently)
+
+    method=$1
+    uri=$2
+    token=${3:-${GITHUB_OAUTH_TOKEN}}
+
+    # Use \n as argument separator to avoid problems with spaces
+    curl_args="-X\n$method\n-H\nContent-Type:application/json"
+
+    # If we have a token, use it
+    if test -n "${token:-}"
+    then
+        curl_args="$curl_args\n-H\nAuthorization: token $token"
+    fi
+
+    # If we have data via stdin, send it as the request data
+    data_file=$(mktemp)
+    cat > "$data_file"
+    if test -s "$data_file"
+    then
+        curl_args="$curl_args\n-d\n@$data_file"
+        ( set -x; cat "$data_file" )
+    fi
+
+    curl_args="$curl_args\nhttps://api.github.com$uri"
+
+    # Send the request
+    printf -- "$curl_args" | xargs -td'\n' curl
+
+    # Remove temporary data file
+    rm -f "$data_file"
+
+    )
+}

--- a/relnotes/d2-release.feature.md
+++ b/relnotes/d2-release.feature.md
@@ -1,0 +1,5 @@
+* `dlang d2-release`
+
+  For D1 projects that are compatible with D2, there is a new special command that allows automatically converting to D2, tagging (using the suffix `+d2`), pushing to the repo and creating a GitHub release.
+
+  Please refer to the *README* for details on how to use this.


### PR DESCRIPTION
The new command, d2-release, automatically converts code to D2, creates a new tag with a `+d2` suffix, pushes to the repo and creates a GitHub release.