### PR TITLE
beaver gives misguided error message

### DIFF
--- a/bin/bintray/upload
+++ b/bin/bintray/upload
@@ -151,7 +151,7 @@ echo "$dest" | grep -qv '^.\+/.\+/.\+$' &&
 	usage_die "You must specify -d DEST if \$TRAVIS_REPO_SLUG is not present " \
 		"(got '$dest')!"
 test -z "$dist" &&
-	usage_die "You must specify -D DEST if \$DIST is not present and " \
+	usage_die "You must specify -D DIST if \$DIST is not present and " \
 		"there is no working lsb_release command!"
 test -z "$user" &&
 	usage_die "You must specify -u USER if \$BINTRAY_USER is not present!"

--- a/bin/bintray/upload
+++ b/bin/bintray/upload
@@ -148,8 +148,10 @@ test -z "$tag" &&
 test "$(git cat-file -t refs/tags/$tag)" != "tag" &&
 	usage_die "'$tag' should be a valid git annotated tag!"
 echo "$dest" | grep -qv '^.\+/.\+/.\+$' &&
-	usage_die "You must specify -d DEST if \$TRAVIS_REPO_SLUG is not present " \
-		"(got '$dest')!"
+	usage_die "Invalid destination, please specify " \
+		"-d <subject>/<repo>/<package> or make sure \$TRAVIS_REPO_SLUG " \
+		"is present if you want to use the default (current invalid " \
+		"value is '$dest')!"
 test -z "$dist" &&
 	usage_die "You must specify -D DIST if \$DIST is not present and " \
 		"there is no working lsb_release command!"


### PR DESCRIPTION
with the command-line: `
docker run --rm -v /home/travis:/home/travis -v /home/travis/build/[secure]/dfmt:/home/travis/build/[secure]/dfmt -w /home/travis/build/[secure]/dfmt -u 2000 -e LANG=C.UTF-8 -e LC_ALL=C.UTF-8 -e USER -e HOME -e DEBIAN_FRONTEND -e RAILS_ENV -e RACK_ENV -e MERB_ENV -e JRUBY_OPTS -e JAVA_HOME -e CI -e CONTINUOUS_INTEGRATION -e TRAVIS_OS_NAME -e TRAVIS_STACK_LANGUAGES -e TRAVIS_BRANCH -e TRAVIS_SUDO -e TRAVIS_PRE_CHEF_BOOTSTRAP_TIME -e TRAVIS_FILTERED -e TRAVIS_PULL_REQUEST_BRANCH -e TRAVIS_PULL_REQUEST_SLUG -e TRAVIS_COMMIT_MESSAGE -e TRAVIS_STACK_NAME -e TRAVIS_STACK_JOB_BOARD_REGISTER -e TRAVIS_REPO_SLUG -e TRAVIS_BUILD_ID -e TRAVIS_COMMIT_RANGE -e TRAVIS -e TRAVIS_ALLOW_FAILURE -e TRAVIS_EVENT_TYPE -e TRAVIS_STACK_FEATURES -e TRAVIS_BUILD_DIR -e TRAVIS_BUILD_NUMBER -e TRAVIS_SECURE_ENV_VARS -e TRAVIS_TAG -e TRAVIS_JOB_ID -e TRAVIS_COMMIT -e TRAVIS_PULL_REQUEST -e TRAVIS_STACK_TIMESTAMP -e TRAVIS_JOB_NUMBER -e TRAVIS_UID -e TRAVIS_PULL_REQUEST_SHA -e TRAVIS_LANGUAGE -e TRAVIS_STACK_NODE_ATTRIBUTES -e TRAVIS_TEST_RESULT -e DIST -e BINTRAY_USER -e BINTRAY_KEY [secure]/dfmt ./beaver/bin/bintray/upload -N -d dlang-community/apt build/last/pkg/dfmt_0.6.0-alpha.36-xenial_amd64.deb`

beaver errror with :

`Error: You must specify -d DEST if $TRAVIS_REPO_SLUG is not present  (got 'dlang-community/apt')`

which is misguiding 