### PR TITLE
dlang/install: Only install dmd-bin

### DIFF
--- a/bin/dlang/install
+++ b/bin/dlang/install
@@ -14,7 +14,7 @@ case "$DMD" in
     dmd*   ) PKG= ;;
     1.*    ) PKG="dmd1=$DMD-$DIST" ;;
     2.*.s* ) PKG="dmd-transitional=$DMD-$DIST" ;;
-    2.*    ) PKG="dmd-bin=$DMD libphobos2-dev=$DMD" ;;
+    2.*    ) PKG="dmd-bin=$DMD" ;;
     *      ) echo "Unknown \$DMD ($DMD)" >&2; exit 1 ;;
 esac
 


### PR DESCRIPTION
Apparently specifying both dmd-bin and libphobos2-dev breaks the
dependency resolution.