### PR TITLE
Add a new general-purpose codecov command

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,44 @@ Travis already have a provider for deploying to bintray, but it is extremely
 inconvenient as it requires to produce one json file per file to upload.
 
 
+Codecov
+-------
+
+Beaver includes a convenient wrapper to send [codecov.io](https://codecov.io/)
+reports. Just make sure the project was already built with coverage support and
+then use something like this in the `.travis.yml` file:
+
+```yml
+after_success: BEAVER_CODECOV_REPORTS="*.lst" beaver codecov [OPTIONS]
+```
+
+The `[OPTIONS]` are forwarded directly to the
+[codecov-bash](https://github.com/codecov/codecov-bash), but this script will
+run in a confined docker instance where only the coverage reports are available,
+plus the original source code as it was in Git (not the, possibly dirtly, build
+workspace).
+
+The docker images used to run the codecov script is determined by the standard
+`BEAVER_DOCKER_IMG` variable, and it is expected that this image was build
+before running `beaver codecov` (normally through the `beaver install` command
+or similar).
+
+Only `TRAVIS*` and `CODECOV_*` environment variables will be automantically
+passed to the docker container. If you want to pass any other environment
+variables use `BEAVER_DOCKER_VARS` as usual.
+
+The reports location must be passed explicitly to the script via the
+`BEAVER_CODECOV_REPORTS` environment variable. Glob patterns (like `*.lst`) and
+directories can be used (they will be copied recursively), but special
+characters are not escaped from the shell, so be careful if files have special
+characters, they must be properly escaped.
+
+Some options are passed to codecov by default (at the moment `-n beaver -s
+reports`, where `reports` is the location of the sanitized sandbox where reports
+are copied; please check the `bin/beaver-codecov` script if you are interested
+in the details).
+
+
 Building D1/2 projects
 ----------------------
 
@@ -425,20 +463,15 @@ then use something like this in the `.travis.yml` file:
 after_success: beaver dlang codecov [OPTIONS]
 ```
 
-The `[OPTIONS]` are forwarded directly to the
-[codecov-bash](https://github.com/codecov/codecov-bash), but this script will
-run in a confined docker instance where only the coverage reports are available
-(this means no file list will be sent to codecov).
+This command is based on the global `beaver codecov` command (please read the
+documentation on this command for more details), but automatically selects which
+reports to send, so you don't need to pass the `BEAVER_CODECOV_REPORTS`
+environment variable. Also some extra variables specific to D programs are
+passed and used as flags (`DIST DMD DC F V` etc.). If you want to pass any other
+environment variables use `BEAVER_DOCKER_VARS` as usual.
 
-Only `TRAVIS*`, `CODECOV_*` and some dlang-related (`DIST DMD DC F V` etc.)
-environment variables will be automantically passed to the docker container. If
-you want to pass any other environment variables use `BEAVER_DOCKER_VARS` as
-usual.
-
-The following environment variables are reported automatically to codecov (via
-the `-e` option): `DIST`, `DMD`, `DC`, `F`. Some other options are passed to
-codecov by default, please check the `bin/dlang/codecov` script if you are
-interested in the details.
+Please check the `bin/dlang/codecov` script if you are interested in the
+details.
 
 
 ### Auto-convert and release tags for D2

--- a/bin/beaver
+++ b/bin/beaver
@@ -17,4 +17,8 @@ cmd="$1"
 shift
 
 # Run the module's command
-exec "$d/$module/$cmd" "$@"
+test -x "$d/$module/$cmd" &&
+    exec "$d/$module/$cmd" "$@"
+
+echo "Neither $d/beaver-$module nor $d/$module/$cmd were found!" >&2
+exit 1

--- a/bin/beaver-codecov
+++ b/bin/beaver-codecov
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Copyright sociomantic labs GmbH 2017.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+#
+# Report codecoverage via codecov in a sandboxed environment.
+#
+# This command is just a wrapper to codecov-bash
+# (https://github.com/codecov/codecov-bash) that runs inside docker and with
+# a fixed version of the script. It also only exposes the source code as
+# present in the git repo and the reports to the script, not all the dirty
+# build directory.
+#
+# To pass reports to upload use the variable BEAVER_CODECOV_REPORTS. These
+# reports are passed without any quoting, so globbing can be used, so if any
+# weird characters could appear in the reports file names, you need to escape
+# them properly. Entire directories can be included, the copy will be
+# recursive.
+set -eu
+
+if test -z "${BEAVER_CODECOV_REPORTS:-}"
+then
+    echo "No reports passed via BEAVER_CODECOV_REPORTS!" >&2
+    exit 0
+fi
+
+# Paths
+r="$(readlink -f $(dirname $0)/..)"
+beaver="$r/bin/beaver"
+
+# Export any codecov-specific environment variable
+codecov_vars="$(printenv -0 | sed -zn 's/^\(CODECOV_[^=]\+\)=.*$/\1\n/p' |
+        tr -d '\0')"
+export BEAVER_DOCKER_VARS="${BEAVER_DOCKER_VARS:-} $codecov_vars"
+
+# Arguments to pass to codecov by default
+
+# Copy coverage reports and git structure to a clean directory
+tmp=`mktemp -d`
+trap 'r=$?; rm -fr "$tmp"; exit $r' EXIT INT TERM QUIT
+mkdir -p "$tmp/reports"
+cp -a $BEAVER_CODECOV_REPORTS "$tmp/reports/"
+git archive --format=tar HEAD | (cd "$tmp" && tar xf -)
+cp -a $(git rev-parse --git-dir) "$tmp/"
+cp -av "$r/bin/codecov-bash" "$tmp/codecov"
+
+# Run codecov in the confined environment
+cd "$tmp"
+"$beaver" run ./codecov -n beaver -s reports "$@"

--- a/bin/dlang/codecov
+++ b/bin/dlang/codecov
@@ -4,11 +4,14 @@
 # (See accompanying file LICENSE.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 #
-# Build D applications
+# Report code coverage to codecov for D projects, it is a wrapper on the beaver
+# codecov script but adds more default options on top of it and collects
+# reports automatically (so you don't have to pass BEAVER_CODECOV_REPORTS).
 set -eu
 
 # First check if there are any reports at all
-if test "$(echo .*.lst)" = ".*.lst"
+export BEAVER_CODECOV_REPORTS=".*.lst"
+if test "$(echo ${BEAVER_CODECOV_REPORTS:-})" = "${BEAVER_CODECOV_REPORTS:-}"
 then
     echo "No reports found" >&2
     exit 0
@@ -24,23 +27,9 @@ beaver="$r/bin/beaver"
 # Set the DC and DVER environment variables and export them to docker
 set_dc_dver
 
-# Export any codecov-specific environment variable
-codecov_vars="$(printenv -0 | sed -zn 's/^\(CODECOV_[^=]\+\)=.*$/\1\n/p' |
-        tr -d '\0')"
 # Export D related environment variables
 dlang_vars="DIST DMD DC DVER D2_ONLY F V"
-export BEAVER_DOCKER_VARS="${BEAVER_DOCKER_VARS:-} $codecov_vars $dlang_vars"
-
-# Arguments to pass to codecov by default
-
-# Copy coverage reports and git structure to a clean directory
-tmp=`mktemp -d`
-trap 'r=$?; rm -fr "$tmp"; exit $r' EXIT INT TERM QUIT
-mkdir -p "$tmp/reports"
-cp -a .*.lst "$tmp/reports"
-git archive --format=tar HEAD | (cd "$tmp" && tar xf -)
-cp -a .git "$tmp/"
-cp -av "$r/bin/codecov-bash" "$tmp/codecov"
+export BEAVER_DOCKER_VARS="${BEAVER_DOCKER_VARS:-} $dlang_vars"
 
 # Build codecov flags
 flags=
@@ -58,6 +47,4 @@ done
 
 # Run codecov in the confined environment
 cd "$tmp"
-"$beaver" run ./codecov -n beaver -s reports -e DIST,DMD,DC,F \
-    $flags -X gcov -X coveragepy -X xcode \
-    "$@"
+"$beaver" codecov -e DIST,DMD,DC,F $flags -X gcov -X coveragepy -X xcode "$@"

--- a/relnotes/codecov.feature.md
+++ b/relnotes/codecov.feature.md
@@ -1,0 +1,17 @@
+## New general `codecov` command
+
+A new, general, `beaver codecov` command was added, which is not tied to *dlang*
+builds.
+
+The new command is a wrapper for
+[codecov-bash](https://github.com/codecov/codecov-bash) (the same as `beaver
+dlang codecov` was), but assumes almost nothing about how to pass the reports.
+
+Unlike `beaver dlang codecov`, the reports location must be passed explicitly to
+the script via the `BEAVER_CODECOV_REPORTS` environment variable. Glob patterns
+(like `*.lst`) and directories can be used (they will be copied recursively),
+but special characters are not escaped from the shell, so be careful if files
+have special characters, they must be properly escaped.
+
+The `beaver dlang codecov` command is now based on the new `beaver codecov`
+command.

--- a/test/beaver/test
+++ b/test/beaver/test
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -u
+
+tmpfile=$(mktemp)
+trap "rm $tmpfile" EXIT
+
+set -x
+beaver NOPE --NEIN 2> $tmpfile
+r=$?
+
+set -e
+
+test "$r" -eq 1 && \
+    grep -q "Neither .*/beaver-NOPE nor .*/NOPE/--NEIN were found!" $tmpfile

--- a/test/codecov/test
+++ b/test/codecov/test
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -exu
+
+BEAVER_CODECOV_REPORTS=. beaver codecov -d


### PR DESCRIPTION
A new, general, `beaver codecov` command was added, which is not tied to *dlang* builds.

The new command is a wrapper for [codecov-bash](https://github.com/codecov/codecov-bash) (the same as `beaver dlang codecov` was), but assumes almost nothing about how to pass the reports.

Unlike `beaver dlang codecov`, the reports location must be passed explicitly to the script via the `BEAVER_CODECOV_REPORTS` environment variable. Glob patterns (like `*.lst`) and directories can be used (they will be copied recursively), but special characters are not escaped from the shell, so be careful if files have special characters, they must be properly escaped.

The `beaver dlang codecov` command is now based on the new `beaver codecov` command.