### PR TITLE
dlang/make: Rely on MakD to properly merge cov reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,9 +466,13 @@ after_success: beaver dlang codecov [OPTIONS]
 This command is based on the global `beaver codecov` command (please read the
 documentation on this command for more details), but automatically selects which
 reports to send, so you don't need to pass the `BEAVER_CODECOV_REPORTS`
-environment variable. Also some extra variables specific to D programs are
-passed and used as flags (`DIST DMD DC F V` etc.). If you want to pass any other
-environment variables use `BEAVER_DOCKER_VARS` as usual.
+environment variable. This will be automatically set to the `COVDIR` directory,
+if defined, and it will default to MakD's default `COVDIR` otherwise (but it can
+still be overridden via the `BEAVER_CODECOV_REPORTS` variable if needed).
+
+Also some extra variables specific to D programs are passed and used as flags
+(`DIST DMD DC F V` etc.). If you want to pass any other environment variables
+use `BEAVER_DOCKER_VARS` as usual.
 
 Please check the `bin/dlang/codecov` script if you are interested in the
 details.

--- a/bin/dlang/codecov
+++ b/bin/dlang/codecov
@@ -9,9 +9,11 @@
 # reports automatically (so you don't have to pass BEAVER_CODECOV_REPORTS).
 set -eu
 
+# Default coverage directory
+export BEAVER_CODECOV_REPORTS="${BEAVER_CODECOV_REPORTS:-build/last/tmp/cov}"
+
 # First check if there are any reports at all
-export BEAVER_CODECOV_REPORTS=".*.lst"
-if test "$(echo ${BEAVER_CODECOV_REPORTS:-})" = "${BEAVER_CODECOV_REPORTS:-}"
+if test -z "$(ls -A "$BEAVER_CODECOV_REPORTS")"
 then
     echo "No reports found" >&2
     exit 0

--- a/bin/dlang/codecov
+++ b/bin/dlang/codecov
@@ -10,7 +10,9 @@
 set -eu
 
 # Default coverage directory
-export BEAVER_CODECOV_REPORTS="${BEAVER_CODECOV_REPORTS:-build/last/tmp/cov}"
+BEAVER_CODECOV_REPORTS="${COVDIR:-build/last/tmp/cov}"
+BEAVER_CODECOV_REPORTS="${BEAVER_CODECOV_REPORTS:-${COVDIR}}"
+export BEAVER_CODECOV_REPORTS
 
 # First check if there are any reports at all
 if test -z "$(ls -A "$BEAVER_CODECOV_REPORTS")"

--- a/bin/dlang/codecov
+++ b/bin/dlang/codecov
@@ -46,5 +46,4 @@ do
 done
 
 # Run codecov in the confined environment
-cd "$tmp"
 "$beaver" codecov -e DIST,DMD,DC,F $flags -X gcov -X coveragepy -X xcode "$@"

--- a/bin/dlang/make
+++ b/bin/dlang/make
@@ -16,7 +16,7 @@ beaver="$r/bin/beaver"
 
 # Set the DC and DVER environment variables and export them to docker
 set_dc_dver
-export BEAVER_DOCKER_VARS="${BEAVER_DOCKER_VARS:-} DMD DC DVER D2_ONLY F V"
+export BEAVER_DOCKER_VARS="${BEAVER_DOCKER_VARS:-} DMD DC DVER D2_ONLY F V COV COVDIR COVMERGE"
 
 # We have arguments, forward to make and exit
 if test $# -gt 0
@@ -33,22 +33,8 @@ then
     "$beaver" make d2conv
 fi
 
-# Build default target
+# Build
 "$beaver" make all
 
-# Test and upload coverage reports
-test_cov()
-{
-    what="$1"
-    "$beaver" make "$what"
-    "$beaver" dlang codecov -n "$what" -F "$what"
-    rm -f .*.lst
-}
-
-test_cov unittest
-
-# XXX: Disabled for now because only the last integration test results will be
-#      uploaded until MakD can make sure integrationtest reports are stored
-#      separately. See: https://github.com/sociomantic-tsunami/makd/issues/107
-#test_cov integrationtest
-"$beaver" make integrationtest
+# Test
+"$beaver" make test

--- a/relnotes/cov.migration.md
+++ b/relnotes/cov.migration.md
@@ -1,0 +1,3 @@
+### Code coverage reporting now depends on MakD
+
+MakD v2.2.0 has built-in support to create coverage reports by using `COV=1` when building. This also supports merging coverage reports, which means coverage can be reported for integration tests too.

--- a/test/dlang/d2-only/Makefile
+++ b/test/dlang/d2-only/Makefile
@@ -15,7 +15,7 @@ endif
 all:
 	echo 'We just made "all"' > make-all.stamp
 
-unittest integrationtest:
+test:
 	echo 'We just made "$@"' > make-$@.stamp
 
 d2conv:

--- a/test/dlang/d2-only/test
+++ b/test/dlang/d2-only/test
@@ -11,7 +11,7 @@ beaver dlang install
 cat beaver.Dockerfile.generated
 rm beaver.Dockerfile.generated
 beaver dlang make
-for f in make-all.stamp make-unittest.stamp make-integrationtest.stamp
+for f in make-all.stamp make-test.stamp
 do
     test -f "$f"
     rm "$f"

--- a/test/dlang/install/Makefile
+++ b/test/dlang/install/Makefile
@@ -16,7 +16,7 @@ all:
 	test -f /BUILT-1-Dockerfile -a -f /BUILT-2-build
 	echo 'We just made "all"' > make-all.stamp
 
-unittest integrationtest:
+test:
 	$(DC) -run hello.d
 	dmd --version | grep -q $(DMD)
 	echo 'We just made "$@"' > make-$@.stamp

--- a/test/dlang/install/test
+++ b/test/dlang/install/test
@@ -15,8 +15,7 @@ do
         cat beaver.Dockerfile.generated
         rm beaver.Dockerfile.generated
         beaver dlang make
-        for f in make-all.stamp make-unittest.stamp make-integrationtest.stamp \
-                make-d2conv.stamp
+        for f in make-all.stamp make-test.stamp make-d2conv.stamp
         do
             test -f "$f"
             rm "$f"


### PR DESCRIPTION
Sending of all coverage reports by beaver doesn't work because
integration tests will overwrite each other (it was disabled for now).
Starting with MakD v2.2.0, coverage reports will be merged by D runtime,
so we don't need to care about the subject any more and reports can be
sent all together at the end.