### PR TITLE
Fix beaver docker image deduction

### DIFF
--- a/bin/docker/build
+++ b/bin/docker/build
@@ -5,8 +5,9 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 
 # Look for a suitable image name
-img="${BEAVER_DOCKER_IMG-$(git config hub.upstream)}"
-img="${img:-${TRAVIS_REPO_SLUG:-beaver}}"
+img="${BEAVER_DOCKER_IMG:-$(git config hub.upstream)}"
+img="${img:-$TRAVIS_REPO_SLUG}"
+img="${img:-beaver}"
 
 # Build the docker image
 set -xe


### PR DESCRIPTION
Was missing a colon in a first assignment. Also split into three
separate assignments to make logic more obvious.