### PR TITLE
[Do Not Merge] Revert `make test` to `make integrationtest`

### DIFF
--- a/bin/dlang/make
+++ b/bin/dlang/make
@@ -37,4 +37,4 @@ fi
 "$beaver" make all
 
 # Test
-"$beaver" make test
+"$beaver" make integrationtest


### PR DESCRIPTION
This is for troubleshooting https://github.com/sociomantic-tsunami/dmqnode/pull/48 where Beaver v0.4.0 causes the tests in Travis to hang.