### PR TITLE
Pass DFLAGS from beaver to docker container

### DIFF
--- a/bin/dlang/make
+++ b/bin/dlang/make
@@ -16,7 +16,7 @@ beaver="$r/bin/beaver"
 
 # Set the DC and DVER environment variables and export them to docker
 set_dc_dver
-export BEAVER_DOCKER_VARS="${BEAVER_DOCKER_VARS:-} DMD DC DVER D2_ONLY F V COV COVDIR COVMERGE"
+export BEAVER_DOCKER_VARS="${BEAVER_DOCKER_VARS:-} DMD DC DVER D2_ONLY DFLAGS F V COV COVDIR COVMERGE"
 
 # We have arguments, forward to make and exit
 if test $# -gt 0

--- a/relnotes/dflags.migration.md
+++ b/relnotes/dflags.migration.md
@@ -1,0 +1,7 @@
+### DFLAGS is now passed from environment to docker container
+
+`beaver dlang make`
+
+`beaver dlang make` will now pass the DFLAGS from the environment to the
+running docker container. This allows for specifying custom `DFLAGS` in
+environment to run the make with it.


### PR DESCRIPTION
DFLAGS are often used to customize the build that's running via env.
variable, so they should be passed to the docker container.