### PR TITLE
Add an option to specify repo for package upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,9 +263,10 @@ Files are put in the debian repository `$DIST/(pre)release/ARCH` where `$DIST`
 can also be overriden via command-line arguments and if not present at all
 defaults to `$(lsb_release -cs)`, releases are put in the `release` components
 and pre-releases (tags with a `-` as per [SemVer]() specification) in the
-`prerelease` component. Finally `ARCH` is the architecture and is calculated
-from the Debian package file name (normally packages end with `_ARCH.deb`), but
-can also be overriden via command-line arguments.
+`prerelease` component (unless `-C <comp>` is used, in which case the component
+will be force to be `<comp>` instead). Finally `ARCH` is the architecture and is
+calculated from the Debian package file name (normally packages end with
+`_ARCH.deb`), but can also be overriden via command-line arguments.
 
 For more options and a more in-depth description of defaults run `beaver bintray
 upload -h` for online help.

--- a/bin/bintray/upload
+++ b/bin/bintray/upload
@@ -15,6 +15,7 @@ user="$BINTRAY_USER"
 key="$BINTRAY_KEY"
 publish=true
 override=false
+comp_force=
 comp_release=release
 comp_prerelease=prerelease
 in_docker=true
@@ -71,6 +72,9 @@ Options:
 	don't publish uploaded packages (packages are published by default)
 -o
 	overwrite existing files if they already exist
+-C NAME
+    force the Debian component to be NAME (instead of automatically figure it
+    out and use one of -r or -p)
 -r NAME
 	name of the Debian component for final releases (default: $comp_release)
 -p NAME
@@ -120,7 +124,7 @@ bt()
 # Parse arguments
 ################################################################################
 
-while getopts t:d:D:u:k:Por:p:a:Nh arg
+while getopts t:d:D:u:k:PoC:r:p:a:Nh arg
 do
 	case "$arg" in
 		t) tag="$OPTARG" ;;
@@ -130,6 +134,7 @@ do
 		k) key="$OPTARG" ;;
 		P) publish=false ;;
 		o) override=true ;;
+		r) comp_force="$OPTARG" ;;
 		r) comp_release="$OPTARG" ;;
 		p) comp_prerelease="$OPTARG" ;;
 		a) arch="$OPTARG" ;;
@@ -196,7 +201,9 @@ fi
 # Upload files
 ################################################################################
 
-if echo "$tag" | grep -q -- '.\+-.\+'; then
+if test -n "$comp_force"; then
+    comp="$comp_force"
+elif echo "$tag" | grep -q -- '.\+-.\+'; then
 	comp="$comp_prerelease"
 else
 	comp="$comp_release"

--- a/relnotes/bintray-force-comp.feature.md
+++ b/relnotes/bintray-force-comp.feature.md
@@ -1,0 +1,11 @@
+### The `bintray upload` command learned an option to force a Debian component
+
+For projects that don't comply with SemVer/Neptune, there is a new `beaver
+bintray upload` option to override the Debian *component* to which the package
+will be uploaded.
+
+For example `beaver bintray upload -C stable *.deb` will upload packages to the
+`stable` component instead of the default `release`/`prerelease`. No guessing
+will be made at all, if you need to upload to different components based on
+different conditions, you need to to the distinction yourself and run the
+appropriate `bintray upload -C <comp>` command.


### PR DESCRIPTION
Currently package upload is targeted according to the git tag, and this assumes that any tag containing `-` (a hyphen) is a pre-release and should be targeted to the `prerelease` repo.

This clashes with our practice packaging 3rd-party upstreams, such as https://github.com/sociomantic-tsunami/mxnet/releases, where the release tags are full deb-package versions.

For this reason it would be useful to be able to have an option to specify which repo packages should be uploaded to.

(Note that better still for packages of 3rd-party projects would be an option to promote packages from `prerelease` to `release` without regenerating them, but this is presumably harder to achieve and is not in beaver's scope.)