### PR TITLE
Allow passing beaver options via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ Usage
   ```
 
 
+Passing option
+--------------
+
+Most options to the `beaver` commands and sub-commands are passed via
+environment variables that start with `BEAVER_`. Options can also be passed via
+CLI options by using `--option`, which at the end it also exports the equivalent
+environment variable.
+
+For example, `BEAVER_DOCKER_IMG=test beaver docker build` is the same as `beaver
+--docker-img test docker install` (or `beaver --docker-img=test docker build`).
+
+These options can only be passed at the beginning (before the beaver command),
+so `beaver docker --docker-img test build` and `beaver docker build
+--docker-img test` won't work).
+
+
 Docker
 ------
 
@@ -59,12 +75,12 @@ The simplest use case would be:
 default options (`--pull -t $img` in particular).
 
 The image name will be taken from the `BEAVER_DOCKER_IMG` environment variable,
-if present. If not present it falls back to the result of `git config
-hub.upstream` (in case you are using the
-[git-hub](https://github.com/sociomantic-tsunami/git-hub) tool in the
-command-line. If that's empty too, then it will try with the `TRAVIS_REPO_SLUG`
-environment variable (in case it's running inside travis) and as a last resort
-it will simply use `beaver` as the image name.
+if present (can also be passed via `beaver --docker-img=...` CLI option). If not
+present it falls back to the result of `git config hub.upstream` (in case you
+are using the [git-hub](https://github.com/sociomantic-tsunami/git-hub) tool in
+the command-line. If that's empty too, then it will try with the
+`TRAVIS_REPO_SLUG` environment variable (in case it's running inside travis) and
+as a last resort it will simply use `beaver` as the image name.
 
 You can pass extra `docker build` options to `beaver docker build`, for example
 to use a different `Dockerfile`:
@@ -111,8 +127,8 @@ script:
 ```
 
 If you need to pass extra variables to `docker run` you can do it by using the
-`BEAVER_DOCKER_VARS` environment variable. To make it globally, you can do, for
-example:
+`BEAVER_DOCKER_VARS` environment variable (or `beaver --docker-vars` CLI
+option). To make it globally, you can do, for example:
 
 ```yml
 env:
@@ -127,7 +143,7 @@ install: beaver docker build -f "docker/Dockerfile.$DIST" .
 ```
 
 You can also pass extra options to `docker` by exporting the
-`BEAVER_DOCKER_OPTS`.
+`BEAVER_DOCKER_OPTS` (or using `beaver --docker-opts=--whatever docker ...`).
 
 The docker image name is `beaver`.
 
@@ -204,11 +220,12 @@ a `.dockerignore` file yet](https://github.com/moby/moby/issues/12886), beaver
 adds some support to overcome this limitation.
 
 To use multiple build contexts, you can specify the variable
-`BEAVER_DOCKER_CONTEXT` to point to a directory that will contain your
-`Dockerfile` or `beaver.Dockerfile` and possibly a `build` script (equivalent
-to the `docker/build` script in normal builds) and/or a `dockerignore`
-(`.dockerignore is also accepted but `dockerignore` will take precedence), which
-will be copied to the current working directory as `.dockerignore`.
+`BEAVER_DOCKER_CONTEXT` (or `--docker-context` CLI option) to point to
+a directory that will contain your `Dockerfile` or `beaver.Dockerfile` and
+possibly a `build` script (equivalent to the `docker/build` script in normal
+builds) and/or a `dockerignore` (`.dockerignore is also accepted but
+`dockerignore` will take precedence), which will be copied to the current
+working directory as `.dockerignore`.
 
 For example:
 ```
@@ -296,7 +313,7 @@ reports. Just make sure the project was already built with coverage support and
 then use something like this in the `.travis.yml` file:
 
 ```yml
-after_success: BEAVER_CODECOV_REPORTS="*.lst" beaver codecov [OPTIONS]
+after_success: beaver --codecov-reports="*.lst" codecov [OPTIONS]
 ```
 
 The `[OPTIONS]` are forwarded directly to the
@@ -315,10 +332,10 @@ passed to the docker container. If you want to pass any other environment
 variables use `BEAVER_DOCKER_VARS` as usual.
 
 The reports location must be passed explicitly to the script via the
-`BEAVER_CODECOV_REPORTS` environment variable. Glob patterns (like `*.lst`) and
-directories can be used (they will be copied recursively), but special
-characters are not escaped from the shell, so be careful if files have special
-characters, they must be properly escaped.
+`BEAVER_CODECOV_REPORTS` environment variable (or `--codecov-reports` CLI
+options). Glob patterns (like `*.lst`) and directories can be used (they will be
+copied recursively), but special characters are not escaped from the shell, so
+be careful if files have special characters, they must be properly escaped.
 
 Some options are passed to codecov by default (at the moment `-n beaver -s
 reports`, where `reports` is the location of the sanitized sandbox where reports

--- a/bin/beaver
+++ b/bin/beaver
@@ -3,22 +3,138 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
+set -ue
 
 d="$(dirname "$0")"
+
+list_commads()
+{
+    ls "$d"/beaver-* | sed 's|^.*/beaver-\([^/]\+\)$|\1|'
+    for mod in $(find "$d" -mindepth 1 -type d)
+    do
+        submods=$(echo "$mod"/* | xargs -n1 basename | sort)
+        echo "$(basename "$mod") ("$submods")"
+    done
+}
+
+usage()
+{
+    cat <<EOT
+Usage: $0 [OPTS] CMD...
+
+OPTS
+
+--help, -h
+  print this help and exit.
+
+--some-opt ARG, --some-opt=ARG
+  overrides environment variable BEAVER_SOME_OPT with ARG.
+  This is just a nicer way to write:
+    BEAVER_SOME_OPT=ARG beaver CMD [CMD_OPTS]
+
+CMD...
+  the beaver command to run and its arguments.
+
+  Available comands (and sub-commands) are:
+EOT
+    list_commads | sort | sed 's/.*/    \0/'
+}
+
+args_error()
+{
+    echo "Error: $@" >&2
+    echo >&2
+    usage >&2
+    exit 2
+}
+
+# Parse general beaver args
+
+pos_only=0
+needs_arg=0
+prev_arg=
+# We use an argument rotation trick to pop arguments from the front and remove
+# them if they are common arguments
+for arg
+do
+    shift
+
+    # We are waiting for an argument of an option
+    if test "$needs_arg" = 1
+    then
+        needs_arg=0
+        export $args_name="$arg"
+
+    # If the argument is a plain "--" we error, as we don't support that
+    elif test "$arg" = "--"
+    then
+        args_error "Invalid option '--' before the beaver command"
+
+    # Print help and exit if --help or -h is found
+    elif test "$arg" = "--help" -o "$arg" = "-h"
+    then
+        usage
+        exit 0
+
+    # We are not just parsing positional arguments and the arg starts with "--"
+    elif test "$pos_only" != 1 -a "$(echo "$arg" | cut -c1-2)" = "--"
+    then
+        args_name="BEAVER_$(echo "$arg" | sed 's/^--\([^=]\+\)=\?.*$/\1/' |
+                tr '[:lower:]-' '[:upper:]_')"
+        if echo "$arg" | grep -q '='
+        then
+            arg="$(echo "$arg" | sed 's/^--[^=]\+=//')"
+            export $args_name="$arg"
+        else
+            prev_arg="$arg"
+            needs_arg=1
+        fi
+
+    # We found a positional argument, so we stop processing and just keep
+    # adding arguments untouched
+    else
+        pos_only=1
+        set -- "$@" "$arg"
+    fi
+done
+
+if test "$needs_arg" = 1
+then
+    args_error "$prev_arg needs an argument"
+fi
+
+if test $# -lt 1
+then
+    args_error "Missing a CMD to run"
+fi
 
 # Look if the module is already present as a built-in beaver command
 module="$1"
 shift
-test -x "$d/beaver-$module" &&
+if test -x "$d/beaver-$module"
+then
 	exec "$d/beaver-$module" "$@"
+fi
 
 # If not get the command
-cmd="$1"
-shift
+if test $# -ge 1
+then
+    cmd="$1"
+    shift
+elif test -d "$d/$module"
+then
+    args_error "Command '$module' needs a sub-command"
+else
+    args_error "Command '$module' not found"
+fi
 
 # Run the module's command
-test -x "$d/$module/$cmd" &&
+if test -x "$d/$module/$cmd"
+then
     exec "$d/$module/$cmd" "$@"
+elif test -d "$d/$module"
+then
+    args_error "No sub-command '$cmd' for command '$module'" >&2
+fi
 
-echo "Neither $d/beaver-$module nor $d/$module/$cmd were found!" >&2
-exit 1
+args_error "Command '$module' not found" >&2

--- a/relnotes/cli-override.feature.md
+++ b/relnotes/cli-override.feature.md
@@ -1,0 +1,15 @@
+### Most options can be set also via CLI
+
+`beaver`
+
+The `beaver` command and sub-commands take some options that need to be
+propagated to other sub-commands via environment variables. This could be too
+verbose and bloated for some use cases.
+
+Now any environment variable that starts with `BEAVER_` can be set via CLI. This
+is done using a simple mapping, where `beaver --some-option value` is equivalent
+to `BEAVER_SOME_OPTION=VALUE beaver`.
+
+This kind of options can only be passed before a `beaver` command is specified
+(so you can use `beaver command --some-option value`, you have to write it as
+`beaver --some-option value command`.

--- a/test/beaver/test
+++ b/test/beaver/test
@@ -1,14 +1,44 @@
 #!/bin/sh
-set -u
+set -eu
 
-tmpfile=$(mktemp)
-trap "rm $tmpfile" EXIT
+TESTS=$(cat <<EOT
+beaver NOPE --NEIN,2,,Error: Command 'NOPE' not found
+beaver,2,,Error: Missing a CMD to run
+beaver dlang NOPE --NEIN,2,,Error: No sub-command 'NOPE' for command 'dlang'
+beaver dlang,2,,Error: Command 'dlang' needs a sub-command
+beaver --some-option,2,,Error: --some-option needs an argument
+beaver --some-option 5 -- cmd,2,,Error: Invalid option '--' before the beaver command
+beaver --some-option 5 cmd,2,,Error: Command 'cmd' not found
+EOT
+)
 
-set -x
-beaver NOPE --NEIN 2> $tmpfile
-r=$?
+outfile=$(mktemp)
+errfile=$(mktemp)
+trap "r=\$?; if test \$r -eq 0; then rm $outfile $errfile; fi; exit \$r" EXIT
 
-set -e
+echo "$TESTS" | while IFS='' read -r t
+do
+    cmd=$(echo "$t" | cut -d, -f1)
+    ret=$(echo "$t" | cut -d, -f2)
+    out=$(echo "$t" | cut -d, -f3)
+    err=$(echo "$t" | cut -d, -f4)
 
-test "$r" -eq 1 && \
-    grep -q "Neither .*/beaver-NOPE nor .*/NOPE/--NEIN were found!" $tmpfile
+    set +e -x
+    $cmd > "$outfile" 2> "$errfile"
+    r=$?
+    set -e
+    test "$r" -eq "$ret"
+    if test -z "$out"
+    then
+        test -z "$(cat "$outfile")"
+    else
+        grep -q "$out" "$outfile"
+    fi
+    if test -z "$err"
+    then
+        test -z "$(cat "$errfile")"
+    else
+        grep -q "$err" "$errfile"
+    fi
+    set +x
+done

--- a/test/multi-install/test
+++ b/test/multi-install/test
@@ -7,15 +7,21 @@ set -xeu
 
 test_run()
 {
+    args=
+    if test "${2:-}" = "pass-args"
+    then
+        args="--docker-img img${1} --docker-context=img${1}"
+    fi
     true "--------------------"
     echo "Running test on img${1}..."
-    beaver docker run test -f /BUILT-img${1}-Dockerfile -a \
+    beaver $args docker run test -f /BUILT-img${1}-Dockerfile -a \
             -f /BUILT-img${1}-Dockerfile-COPY -a \
             -f /BUILT-img${1}-build
-    beaver docker run cat /BUILT-img${1}-Dockerfile-COPY
+    beaver $args docker run cat /BUILT-img${1}-Dockerfile-COPY
     cat img${1}/build
-    test "$(beaver docker run cat /BUILT-img${1}-Dockerfile-COPY | md5sum)" = \
-            "$(md5sum < img${1}/build)"
+    md5real=$(beaver $args docker run cat /BUILT-img${1}-Dockerfile-COPY |
+            md5sum)
+    test "$md5real" = "$(md5sum < img${1}/build)"
 }
 
 # Use xenial
@@ -42,6 +48,16 @@ true "======================================================================="
 export BEAVER_DOCKER_IMG=img1 BEAVER_DOCKER_CONTEXT=img1
 DMD=dmd1 beaver dlang install
 test_run 1
+
+true "======================================================================="
+# Build and run second image (with Dockerfile.xenial)
+beaver --docker-img img2 --docker-context=img2 install
+test_run 2 pass-args
+
+true "======================================================================="
+# Build and run first first image with dlang install
+DMD=dmd1 beaver --docker-img img1 --docker-context=img1 dlang install
+test_run 1 pass-args
 
 true "======================================================================="
 # Interleaved runs between both images


### PR DESCRIPTION
Add the ability to pass options as `beaver --some-opt value cmd`, which is equivalent to using `BEAVER_SOME_OPT=value beaver cmd`.

Fixes #53.