### PR TITLE
bintray: Fix -C <component> option for upload

### DIFF
--- a/bin/bintray/upload
+++ b/bin/bintray/upload
@@ -134,7 +134,7 @@ do
 		k) key="$OPTARG" ;;
 		P) publish=false ;;
 		o) override=true ;;
-		r) comp_force="$OPTARG" ;;
+		C) comp_force="$OPTARG" ;;
 		r) comp_release="$OPTARG" ;;
 		p) comp_prerelease="$OPTARG" ;;
 		a) arch="$OPTARG" ;;


### PR DESCRIPTION
This patch tweaks a small typo in the original `-C` flag implementation: the arguments parsing accidentally specified an `r` instead of the `C` that is actually needed.