### PR TITLE
install: Only remove .dockerignore if it wasn't present

### DIFF
--- a/bin/beaver-install
+++ b/bin/beaver-install
@@ -10,17 +10,30 @@ d="$(dirname "$0")"
 # Copy a file only if it exist
 maybe_cp()
 {
-    if test -f "$1"
+    # Don't do anything if both src and dst are the same, or if src doesn't
+    # exist
+    if test "$(readlink -m "$1")" != "$(readlink -m "$2")" -a test -f "$1"
     then
         cp -v "$1" "$2"
     fi
 }
 
+# Store if a .dockerignore existed already
+dockerignore=false
+if test -f ".dockerignore"
+then
+    dockerignore=true
+fi
+
 # Look if a particular context was given and copy the .dockerfile from it
 if test -n "${BEAVER_DOCKER_CONTEXT:-}"
 then
-    trap 'r=$?; if test $r -eq 0 -a "${BEAVER_DEBUG:-0}" -ne 1; \
-            then rm -f .dockerignore; fi; exit $r' EXIT
+    # Only remove .dockerignore if none existed
+    if ! $dockerignore
+    then
+        trap 'r=$?; if test $r -eq 0 -a "${BEAVER_DEBUG:-0}" -ne 1; \
+                then rm -f .dockerignore; fi; exit $r' EXIT
+    fi
     maybe_cp "$BEAVER_DOCKER_CONTEXT/.dockerignore" .dockerignore
     maybe_cp "$BEAVER_DOCKER_CONTEXT/dockerignore" .dockerignore
     docker_dir="-d $BEAVER_DOCKER_CONTEXT"

--- a/bin/dlang/install
+++ b/bin/dlang/install
@@ -26,16 +26,26 @@ esac
 # Copy a file only if it exist
 maybe_cp()
 {
-    if test -f "$1"
+    if test "$(readlink -m "$1")" != "$(readlink -m "$2")" -a test -f "$1"
     then
         cp -v "$1" "$2"
     fi
 }
+# Store if a .dockerignore existed already
+dockerignore=false
+if test -f ".dockerignore"
+then
+    dockerignore=true
+fi
 # Look if a particular context was given and copy the .dockerfile from it
 if test -n "${BEAVER_DOCKER_CONTEXT:-}"
 then
-    trap 'r=$?; if test $r -eq 0 -a "${BEAVER_DEBUG:-0}" -ne 1; \
-            then rm -f .dockerignore; fi; exit $r' EXIT
+    # Only remove .dockerignore if none existed
+    if ! $dockerignore
+    then
+        trap 'r=$?; if test $r -eq 0 -a "${BEAVER_DEBUG:-0}" -ne 1; \
+                then rm -f .dockerignore; fi; exit $r' EXIT
+    fi
     maybe_cp "$BEAVER_DOCKER_CONTEXT/.dockerignore" .dockerignore
     maybe_cp "$BEAVER_DOCKER_CONTEXT/dockerignore" .dockerignore
     docker_dir="-d $BEAVER_DOCKER_CONTEXT"
@@ -58,5 +68,5 @@ fi
 
 if test "${BEAVER_DEBUG:-0}" -ne 1
 then
-    rm -f beaver.Dockerfile.generated .dockerignore
+    rm -f beaver.Dockerfile.generated
 fi

--- a/tools/make-wrapper-dlang
+++ b/tools/make-wrapper-dlang
@@ -38,7 +38,6 @@ build()
 	eval echo "+ MATRIX: "$matrix >&2
 	export DIST=${DIST:-$(lsb_release -cs)} DMD="${DMD:-dmd1}" TRAVIS=1
 	"$beaver" dlang install
-	rm beaver.Dockerfile.generated
 	"$beaver" dlang make "$@"
 }
 


### PR DESCRIPTION
If there is already a top-level .dockerignore, don't remove it.
A .dockerignore should only be ignored if it was copied from
a BEAVER_DOCKER_CONTEXT.