### PR TITLE
dlang: Add dlang setup sub-command

### DIFF
--- a/bin/dlang/install
+++ b/bin/dlang/install
@@ -9,18 +9,7 @@ set -eu
 
 beaver=$(dirname $0)/../beaver
 
-# Package name deduced based on supplied DMD version
-case "$DMD" in
-    dmd*   ) PKG= ;;
-    1.*    ) PKG="dmd1=$DMD-$DIST" ;;
-    2.*.s* ) PKG="dmd-transitional=$DMD-$DIST" ;;
-    2.*    ) if [ $(echo $DMD | cut -d. -f2) -ge 077 ]; then
-                PKG="dmd-compiler=$DMD dmd-tools=$DMD libphobos2-dev=$DMD"
-             else
-                PKG="dmd-bin=$DMD libphobos2-dev=$DMD"
-             fi ;;
-    *      ) echo "Unknown \$DMD ($DMD)" >&2; exit 1 ;;
-esac
+. $(dirname $0)/../../lib/dlang.sh
 
 # FIXME: Use beaver install for this for consistency and DRY
 # Copy a file only if it exist
@@ -63,7 +52,7 @@ fi
         -o beaver.Dockerfile.generated
 
 # Build the docker image from the generated Dockerfile passing DMD_PKG
-"$beaver" docker build --build-arg "DMD_PKG=$PKG" \
+"$beaver" docker build --build-arg "DMD_PKG=$(get_d_pkg "$DMD" "$DIST")" \
         -f beaver.Dockerfile.generated "$@" .
 
 if test "${BEAVER_DEBUG:-0}" -ne 1

--- a/bin/dlang/setup
+++ b/bin/dlang/setup
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Copyright dunnhumby Germany GmbH 2019.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+#
+# Setup the environment assuming we are already running inside a docker
+# container with permissions to run apt install.
+set -eu
+
+beaver=$(dirname $0)/../beaver
+
+. $(dirname $0)/../../lib/dlang.sh
+
+# Install the compiler
+apt update
+apt -y install --allow-downgrades $(get_d_pkg "$DMD" "$DIST")
+
+# Do extra user setup, if applicable
+if test -x docker/build
+then
+    docker/build
+fi

--- a/lib/dlang.sh
+++ b/lib/dlang.sh
@@ -9,6 +9,41 @@
 #
 # . lib/dlang.sh
 
+# Print the Debian package name (with version specification) to install
+# based on DMD version.
+# $1 is the DMD version description.
+# $2 is the DIST ubuntu version.
+# If DMD starts with dmd, it will print nothing, assuming the default
+#        installed packages will be used
+# If DMD is 1.* it will print dmd1=$1-$2
+# If DMD is 2.*.s*, it will print dmd-transitional=$1-$2
+# If DMD is 2.* it will print dmd-compiler=$1 or dmd-bin=$1 depending on
+#        $1 (to accomodate to a package name change) and some extra
+#        packages, like libphobos2-dev and dmd-tools
+# If DMD has another shape, it will print an error to stderr, nothing to
+# stdout and exit.
+get_d_pkg() {
+    old_opts=$-
+    set -eu
+
+    DMD="$1"
+    DIST="$2"
+
+    case "$DMD" in
+        dmd*   ) echo "" ;;
+        1.*    ) echo "dmd1=$DMD-$DIST" ;;
+        2.*.s* ) echo "dmd-transitional=$DMD-$DIST" ;;
+        2.*    ) if [ $(echo $DMD | cut -d. -f2) -ge 077 ]; then
+                    echo "dmd-compiler=$DMD dmd-tools=$DMD libphobos2-dev=$DMD"
+                 else
+                    echo "dmd-bin=$DMD libphobos2-dev=$DMD"
+                 fi ;;
+        *      ) echo "Unknown \$DMD ($DMD)" >&2; exit 1 ;;
+    esac
+
+    set -$old_opts
+}
+
 # Sets the DC and DVER environment variables based on the DMD environment
 # variable, if present. The DMD variable is expected to hold the DMD version to
 # use:


### PR DESCRIPTION
The new sub-command is intended to just do the basic setup of an already existing container, installing the proper compiler version and running the user's setup/build script.

As part of this, to reuse code, the package name/version calculation is moved to lib/dlang.sh.

This is a WIP to add GitLab support.